### PR TITLE
Shouldn't add a new executable if the dialog is canceled

### DIFF
--- a/Launcher.xaml.cs
+++ b/Launcher.xaml.cs
@@ -345,12 +345,12 @@ namespace CasparLauncher
             if (openFileDialog.ShowDialog() == true)
             {
                 executable = Settings.AddExecutable(openFileDialog.FileName);
+                OpenExecutableOptions(executable);
             }
             else
             {
-                executable = Settings.AddExecutable();
+                return;
             }
-            OpenExecutableOptions(executable);
         }
 
         private void ExecutableConfig_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
When canceling the "add executable" openfiledialog, we should not add an empty executable.